### PR TITLE
fixed camelCase issue with appname property

### DIFF
--- a/src/main/resources/appmon4jWeb.spring.xml
+++ b/src/main/resources/appmon4jWeb.spring.xml
@@ -27,7 +27,7 @@
     <property name="targetMethod"><value>readJMXExporterPatternFromDir</value></property>
     <property name="arguments">
       <list>
-        <value>/etc/appmon4j-jmxexport/${appname:web}</value>
+        <value>/etc/appmon4j-jmxexport/${appName:web}</value>
       </list>
     </property>
   </bean>


### PR DESCRIPTION
You have used two different versions of "appname" property in your spring configuration files:
- appName
- appname

I have removed the second one
